### PR TITLE
Added amazonec2-zone parameters to docker-machine create commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ export AWS_ACCESS_KEY_ID=<secret key>
 export AWS_SECRET_ACCESS_KEY=<secret access key>
 export AWS_VPC_ID=<vpc-id>
 export AWS_DEFAULT_REGION=eu-central-1
+export AWS_DEFAULT_ZONE=<zone>
 ```
 
 The values for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY can be obtained from the AWS admin console. 
 
-The value for AWS_VPC_ID will also be available from the console, as the AWS provisioning process creates a VPC called ```tldr-vpc```. Once the AWS provisioning process via Terraform is complete, use the AWS admin console to obtain the id of the ```tldr-vpc```VPC resource, e.g. ```vpc-fe53be97```.
+The value for AWS_VPC_ID and AWS_DEFAULT_ZONE will also be available from the console, as the AWS provisioning process creates a VPC called ```tldr-vpc```. Once the AWS provisioning process via Terraform is complete, use the AWS admin console to obtain the id of the ```tldr-vpc```VPC resource, e.g. ```vpc-fe53be97``` and the respective zone of the VPC subnet e.g. ```b```.
 
 ### Overriding EC2 instance sizes
 

--- a/bin/providers/aws/provider.sh
+++ b/bin/providers/aws/provider.sh
@@ -45,6 +45,8 @@ function create_registry_node() {
 	  docker-machine create --driver amazonec2 \
 	  						--amazonec2-security-group \
 	  						$TLDR_REGISTRY_SG_NAME \
+							--amazonec2-zone \
+							$AWS_DEFAULT_ZONE \
 	  						$REGISTRY_MACHINE_NAME
 	  if [ $? -ne 0 ]; then
 	    error "There was a problem creating the node."
@@ -75,7 +77,9 @@ function create_infra_node() {
 	  docker-machine create -d amazonec2 \
 	    --amazonec2-security-group $TLDR_INFRA_NODE_SG_NAME \
 	    --amazonec2-instance-type t2.large \
-	    --engine-insecure-registry=$REGISTRY $INFRA_MACHINE_NAME
+	    --engine-insecure-registry=$REGISTRY \
+	    --amazonec2-zone $AWS_DEFAULT_ZONE \
+		$INFRA_MACHINE_NAME
 	fi
 
 	eval $(docker-machine env $INFRA_MACHINE_NAME)
@@ -101,6 +105,7 @@ function create_swarm_master() {
 	    $OPTIONS \
 	    --swarm-image $REGISTRY/swarm \
 	    --amazonec2-ami="$TLDR_DOCKER_MACHINE_AMI" --amazonec2-security-group="$TLDR_NODE_SG_NAME" \
+	    --amazonec2-zone $AWS_DEFAULT_ZONE \
 	    $NAME
 	  info "Creating network tldr-overlay"
 	  docker $(docker-machine config $NAME) network create --driver overlay tldr-overlay
@@ -133,7 +138,9 @@ function create_swarm_node() {
 	     --engine-opt="log-opt syslog-address=$LOGSTASH" \
 	     $EXTRA_OPTS \
 	     --engine-insecure-registry="$REGISTRY" \
-	     --amazonec2-ami="$TLDR_DOCKER_MACHINE_AMI" --amazonec2-security-group="$TLDR_NODE_SG_NAME" $NAME
+	     --amazonec2-ami="$TLDR_DOCKER_MACHINE_AMI" --amazonec2-security-group="$TLDR_NODE_SG_NAME" \
+	     --amazonec2-zone $AWS_DEFAULT_ZONE \
+	     $NAME
 	  info "Starting Consul agent"
 	  docker $(docker-machine config $NAME) run -d -p 172.17.0.1:53:53 -p 172.17.0.1:53:53/udp -p 8500:8500 --name $NAME-consul --net tldr-overlay $REGISTRY/consul -join $OVERLAY_CONSUL
 	else


### PR DESCRIPTION
Docker uses availability zone 'a' as default when creating new machines. However the terraform script might create VPC subnet to other availability zones e.g. 'b' and due to this it needs to be given as parameter when creating new machines.
